### PR TITLE
Generalized mitochondrial QC for mouse genes

### DIFF
--- a/modules/local/spatial_quality_control/spatial_quality_control.py
+++ b/modules/local/spatial_quality_control/spatial_quality_control.py
@@ -73,7 +73,6 @@ def qc_from_h5ad(
         adata.X = sp.sparse.csr_matrix(adata.X)
 
     # Flag genes for QC
-    # adata.var["mt"] = adata.var_names.str.startswith("MT-")
     adata.var["gene_symbols_upper"] = adata.var_names.str.upper()
 
     adata.var["mt"] = adata.var["gene_symbols_upper"].str.startswith("MT-")

--- a/modules/local/spatial_quality_control/spatial_quality_control.py
+++ b/modules/local/spatial_quality_control/spatial_quality_control.py
@@ -73,9 +73,12 @@ def qc_from_h5ad(
         adata.X = sp.sparse.csr_matrix(adata.X)
 
     # Flag genes for QC
-    adata.var["mt"] = adata.var_names.str.startswith("MT-")
-    adata.var["ribo"] = adata.var_names.str.startswith(('RPS','RPL'))
-    adata.var["hb"] = adata.var_names.str.startswith("HB")
+    # adata.var["mt"] = adata.var_names.str.startswith("MT-")
+    adata.var["gene_symbols_upper"] = adata.var_names.str.upper()
+
+    adata.var["mt"] = adata.var["gene_symbols_upper"].str.startswith("MT-")
+    adata.var["ribo"] = adata.var["gene_symbols_upper"].str.startswith(('RPS','RPL'))
+    adata.var["hb"] = adata.var["gene_symbols_upper"].str.startswith("HB")
 
     # Calculate QC metrics
     sc.pp.calculate_qc_metrics(


### PR DESCRIPTION
* QC for mitochondrial gene reads: in __modules/local/spatial_quality_control/spatial_quality_control.py__ added creation of `gene_symbols_upper` in var to recognize mitochondrial genes both in mouse and human. 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nfdata-omics/spatialomics/tree/master/docs/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
